### PR TITLE
修改部分链接指向地址

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -60,7 +60,7 @@ registerList([
 ]);
 ```
 
-You can find the dictionary script source code sample under [/dicts](https://github.com/ninja33/ODH/master/dicts) of this repository.
+You can find the dictionary script source code sample under [/dicts](https://github.com/ninja33/ODH/tree/master/src/bg/local) of this repository.
 
 ## Security issue
 


### PR DESCRIPTION
原地址指向https://github.com/ninja33/ODH/master/dicts 是个空地址。修改为你前文提及的https://github.com/ninja33/ODH/tree/master/src/bg/local。