### PR TITLE
Update enfr_Collins.js

### DIFF
--- a/src/dict/enfr_Collins.js
+++ b/src/dict/enfr_Collins.js
@@ -81,6 +81,9 @@ class enfr_Collins {
                     word-wrap: break-word;
                     box-sizing: border-box;
                 }
+                 .mpuslot_b-container{
+                      display: none;
+                }
             </style>`;
 
         return css;


### PR DESCRIPTION
To remove empty big box. 
But still not able to view properly on anki desktop version, on which it displays Invalid HTML on card: ReferenceError: googletag is not defined.
This bug has nothing to do with the templates you are using, it's unable to display even with the most simple template without CSS.
Please help solve this issue, because there are many similar dictionaries on the Collins website.