### PR TITLE
removes redundant tooltip information

### DIFF
--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -109,7 +109,7 @@ class esen_Spanishdict {
                 font-style: normal;
             }
 
-            ._1TNZVHD7, ._3_OedT5w {
+            ._1TNZVHD7, .DuSbDKLr {
                 display: none;
             }
             </style>`;

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -109,7 +109,7 @@ class esen_Spanishdict {
                 font-style: normal;
             }
 
-            ._1TNZVHD7, .DuSbDKLr, _3_OedT5w {
+            ._1TNZVHD7, .DuSbDKLr, _3_OedT5w, button {
                 display: none;
             }
             </style>`;

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -109,7 +109,7 @@ class esen_Spanishdict {
                 font-style: normal;
             }
 
-            ._1TNZVHD7, .DuSbDKLr {
+            ._1TNZVHD7, .DuSbDKLr, _3_OedT5w {
                 display: none;
             }
             </style>`;

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -108,6 +108,10 @@ class esen_Spanishdict {
                 color: #7b7b7b;
                 font-style: normal;
             }
+
+            ._1TNZVHD7 {
+                display: none;
+            }
             </style>`;
 
         return css;

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -109,15 +109,7 @@ class esen_Spanishdict {
                 font-style: normal;
             }
 
-            ._1TNZVHD7, .DuSbDKLr, _3_OedT5w, button {
-                display: none;
-            }
-
-            button {
-                display: none;
-            }
-
-            .DuSbDKLr._3_OedT5w {
+            ._1TNZVHD7, button {
                 display: none;
             }
 

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -109,7 +109,7 @@ class esen_Spanishdict {
                 font-style: normal;
             }
 
-            ._1TNZVHD7, button {
+            ._1TNZVHD7 {
                 display: none;
             }
 

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -109,7 +109,7 @@ class esen_Spanishdict {
                 font-style: normal;
             }
 
-            ._1TNZVHD7 {
+            ._1TNZVHD7, ._3_OedT5w {
                 display: none;
             }
             </style>`;

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -116,6 +116,11 @@ class esen_Spanishdict {
             button {
                 display: none;
             }
+
+            .DuSbDKLr._3_OedT5w {
+                display: none;
+            }
+
             </style>`;
 
         return css;

--- a/src/dict/esen_Spanishdict.js
+++ b/src/dict/esen_Spanishdict.js
@@ -112,6 +112,10 @@ class esen_Spanishdict {
             ._1TNZVHD7, .DuSbDKLr, _3_OedT5w, button {
                 display: none;
             }
+
+            button {
+                display: none;
+            }
             </style>`;
 
         return css;


### PR DESCRIPTION
Working fix for issue from #123 .  Spanishdict is built on React framework which obfuscates/minify the class (the reason for weird class name).