### PR TITLE
Update Cambridge script

### DIFF
--- a/src/dict/encn_Cambridge.js
+++ b/src/dict/encn_Cambridge.js
@@ -53,24 +53,29 @@ class encn_Cambridge {
         let definitions = [];
         let audios = [];
         for (const [index, entry] of entries.entries()) {
+            let reading_entry = ''
+            let reading_uk = entry.querySelectorAll('.uk .pron .ipa');
+            let reading_us = entry.querySelectorAll('.us .pron .ipa');
+            if (reading_uk) {
+                reading_entry += `UK /<span class="phonetic">${T(reading_uk[0])}</span>/ `;
+            }
+            if (reading_us) {
+                reading_entry += `US /<span class="phonetic">${T(reading_us[0])}</span>/ `;
+            }
+
             if (index === 0) {
                 expression = T(entry.querySelector('.headword'));
-                let readings_uk = entry.querySelectorAll('.uk .pron .ipa');
-                let readings_us = entry.querySelectorAll('.us .pron .ipa');
-                if (readings_uk) {
-                    reading += `UK[${T(readings_uk[0])}] `;
-                }
-                if (readings_us){
-                    reading += `US[${T(readings_us[0])}] `;
-                }
-
+                reading = reading_entry;
                 audios[0] = entry.querySelector(".uk.dpron-i source");
                 audios[0] = audios[0] ? 'https://dictionary.cambridge.org' + audios[0].getAttribute('src') : '';
                 //audios[0] = audios[0].replace('https', 'http');
                 audios[1] = entry.querySelector(".us.dpron-i source");
                 audios[1] = audios[1] ? 'https://dictionary.cambridge.org' + audios[1].getAttribute('src') : '';
                 //audios[1] = audios[1].replace('https', 'http');
+            } else {
+                definitions.push(`<span class='phonetics'>${reading_entry}</span>`);
             }
+
             let pos = T(entry.querySelector('.posgram'));
             pos = pos ? `<span class='pos'>${pos}</span>` : '';
 


### PR DESCRIPTION
Fixed a US phonetic issue -- The phonetic for US pronunciation is incorrect when there are several different UK pronunciations. For example, 'adverse'. https://dictionary.cambridge.org/dictionary/english-chinese-simplified/adverse

Allowed for adding different part-of-speeches into one entry -- For example, when lookup 'increase', you can either add the definitions for `noun` form or the `verb` form, but not both. This update allows both the `noun` form and `verb` form to be added in a single entry. Though it's not perfect for now. Because ODH does not have the mechanism to record pronunciation for each part-of-speech in a single entry, the pronunciation for other part-of-speeches will be recorded as a definition.

Removed Youdao. -- I don't understand why Youdao appears in the Cambridge script. It's much less accurate than Cambridge definitions and makes the script slower.

Here shows the snapshots before and after this update. If you think these modifications are reasonable, I can also update the Cambridge_tc version accordingly.

<img src="https://user-images.githubusercontent.com/379616/108528915-37d0dc00-72d4-11eb-848d-1b35f3530537.png" width="50%">
<img src="https://user-images.githubusercontent.com/379616/108528930-3b646300-72d4-11eb-8d51-71b2cd8884e6.png" width="50%">



