### PR TITLE
Added support for isContentEditable

### DIFF
--- a/src/fg/js/frontend.js
+++ b/src/fg/js/frontend.js
@@ -29,13 +29,16 @@ class ODHFront {
     }
 
     onKeyDown(e) {
-        if (!this.activateKey)
+        if (!this.enabled)
             return;
 
-        if (!isValidElement())
+        if (!this.activateKey || !(e.keyCode === this.activateKey || e.charCode === this.activateKey))
             return;
 
-        if (this.enabled && this.point !== null && (e.keyCode === this.activateKey || e.charCode === this.activateKey)) {
+        if (!isValidElement(document.activeElement))
+            return;
+
+        if (this.point !== null) {
             const range = rangeFromPoint(this.point);
             if (range == null) return;
             let textSource = new TextSourceRange(range);
@@ -49,11 +52,14 @@ class ODHFront {
     }
 
     onDoubleClick(e) {
+        if (!this.enabled)
+            return;
+
         if (!this.mouseselection)
             return;
 
-        if (!isValidElement())
-            return;
+        // if (!isValidElement(document.activeElement))
+        //     return;
 
         if (this.timeout)
             clearTimeout(this.timeout);
@@ -94,18 +100,21 @@ class ODHFront {
         if (!this.enabled)
             return;
 
-        if (!isValidElement())
-            return;
+        // if (!isValidElement(document.activeElement))
+        //     return;
 
         // reset selection timeout
         this.timeout = null;
         const expression = selectedText();
         if (isEmpty(expression)) return;
 
+        // save the current point before sending translation request
+        const point = this.point;
+
         let result = await getTranslation(expression);
         if (result == null || result.length == 0) return;
         this.notes = this.buildNote(result);
-        this.popup.showNextTo({ x: this.point.x, y: this.point.y, }, await this.renderPopup(this.notes));
+        this.popup.showNextTo({ x: point.x, y: point.y, }, await this.renderPopup(this.notes));
 
     }
 

--- a/src/fg/js/frontend.js
+++ b/src/fg/js/frontend.js
@@ -31,6 +31,9 @@ class ODHFront {
     onKeyDown(e) {
         if (!this.enabled)
             return;
+        
+        if (e.keyCode === this.exitKey || e.charCode === this.exitKey)
+            this.popup.hide();
 
         if (!this.activateKey || !(e.keyCode === this.activateKey || e.charCode === this.activateKey))
             return;
@@ -46,9 +49,6 @@ class ODHFront {
             this.mousemoved = false;
             this.onSelectionEnd(e);
         }
-
-        if (e.keyCode === this.exitKey || e.charCode === this.exitKey)
-            this.popup.hide();
     }
 
     onDoubleClick(e) {
@@ -87,6 +87,11 @@ class ODHFront {
             clearTimeout(this.timeout);
         }
 
+        // if there's no text selected
+        if (window.getSelection().isCollapsed) {
+            return;
+        }
+
         // wait 500 ms after the last selection change event
         this.timeout = setTimeout(() => {
             this.onSelectionEnd(e);
@@ -108,7 +113,7 @@ class ODHFront {
         const expression = selectedText();
         if (isEmpty(expression)) return;
 
-        // save the current point before sending translation request
+        // save the current point before sending the request
         const point = this.point;
 
         let result = await getTranslation(expression);

--- a/src/fg/js/text.js
+++ b/src/fg/js/text.js
@@ -165,7 +165,7 @@ function getSentence(sentenceNum) {
 
     let node = selection.getRangeAt(0).commonAncestorContainer;
 
-    if (['INPUT', 'TEXTAREA'].indexOf(node.tagName) !== -1) {
+    if (!isValidElement(node)) {
         return;
     }
 
@@ -200,13 +200,10 @@ function selectedText() {
     return (selection.toString() || '').trim();
 }
 
-function isValidElement() {
-    // if (document.activeElement.getAttribute('contenteditable')) 
-    //     return false;
-
+function isValidElement(node) {
     const invalidTags = ['INPUT', 'TEXTAREA'];
-    const nodeName = document.activeElement.nodeName.toUpperCase();
-    if (invalidTags.includes(nodeName)) {
+    const nodeName = node.nodeName.toUpperCase();
+    if (invalidTags.includes(nodeName) || node.isContentEditable) {
         return false;
     } else {
         return true;


### PR DESCRIPTION
Some webpages (YouTube comments for example) use `<div>` as text input so `isContentEditable` needs be checked in addition.

Relevant minor changes:
- Allowed double click to trigger popup in text input elements since it won't interfere with text editing like hotkeys do.
- Added a mouse point save before `getTranslation()` to avoid the triggered popup displaying in somewhere else when the network is slow and the mouse is moved.
- Added condition for the timeout to prevent triggering `onSelectionEnd` if there's no text selected.