### PR TITLE
Collins Dictionary Multiple Word Translation

### DIFF
--- a/src/dict/enen_Collins.js
+++ b/src/dict/enen_Collins.js
@@ -38,7 +38,7 @@ class enen_Collins {
         }
 
         let base = 'https://www.collinsdictionary.com/dictionary/english/';
-        let url = base + encodeURIComponent(word);
+        let url = (base + encodeURIComponent(word)).replace(/%20/g, '-');
         let doc = '';
         try {
             let data = await api.fetch(url);


### PR DESCRIPTION
fix: a bug that appears when try to translate multiple words with enen_collins.js bug fixed.
(Collins Dictionary uses '-' instead of "%20%)